### PR TITLE
Migrate to openjfx to make it run on newer java versions

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,3 @@
 language: java
 jdk:
-  - oraclejdk8
+  - oraclejdk11

--- a/pom.xml
+++ b/pom.xml
@@ -6,8 +6,8 @@
 	<version>0.0.2-SNAPSHOT</version>
 	<name>FastImageViewer</name>
 	<properties>
-		<maven.compiler.source>1.8</maven.compiler.source>
-		<maven.compiler.target>1.8</maven.compiler.target>
+		<maven.compiler.source>11</maven.compiler.source>
+		<maven.compiler.target>11</maven.compiler.target>
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 	</properties>
 	<dependencies>
@@ -47,25 +47,44 @@
 			<version>4.12</version>
 			<scope>test</scope>
 		</dependency>
+		<dependency>
+			<groupId>org.openjfx</groupId>
+			<artifactId>javafx-controls</artifactId>
+			<version>13.0.2</version>
+		</dependency>
+		<dependency>
+			<groupId>org.openjfx</groupId>
+			<artifactId>javafx-fxml</artifactId>
+			<version>13.0.2</version>
+		</dependency>
+		<dependency>
+			<groupId>org.openjfx</groupId>
+			<artifactId>javafx-graphics</artifactId>
+			<version>13.0.2</version>
+			<classifier>win</classifier>
+		</dependency>
+		<dependency>
+			<groupId>org.openjfx</groupId>
+			<artifactId>javafx-graphics</artifactId>
+			<version>13.0.2</version>
+			<classifier>linux</classifier>
+		</dependency>
+		<dependency>
+			<groupId>org.openjfx</groupId>
+			<artifactId>javafx-graphics</artifactId>
+			<version>13.0.2</version>
+			<classifier>mac</classifier>
+		</dependency>
 	</dependencies>
 	<build>
 		<plugins>
-			<!-- is javafx plugin needed? -->
-			<plugin>
-				<groupId>com.zenjava</groupId>
-				<artifactId>javafx-maven-plugin</artifactId>
-				<version>8.1.2</version>
-				<configuration>
-					<mainClass>de.moritz.fastimageviewer.main.Main</mainClass>
-				</configuration>
-			</plugin>
 			<plugin>
 				<artifactId>maven-assembly-plugin</artifactId>
 				<version>2.5.5</version>
 				<configuration>
 					<archive>
 						<manifest>
-							<mainClass>de.moritz.fastimageviewer.main.Main</mainClass>
+							<mainClass>de.moritz.fastimageviewer.main.MainLauncher</mainClass>
 						</manifest>
 					</archive>
 					<descriptorRefs>

--- a/src/main/java/de/moritz/fastimageviewer/main/MainLauncher.java
+++ b/src/main/java/de/moritz/fastimageviewer/main/MainLauncher.java
@@ -1,0 +1,8 @@
+package de.moritz.fastimageviewer.main;
+
+public class MainLauncher {
+
+    public static void main(String[] args) {
+        Main.main(args);
+    }
+}


### PR DESCRIPTION
The builtin launcher for jfx applications checks for the existance of the jfx module (jigsaw).

Since we use a fat jar, we need to circumvent this check, see:
https://stackoverflow.com/questions/52653836/maven-shade-javafx-runtime-components-are-missing